### PR TITLE
Add short-lived token

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,12 +30,14 @@ dependencies {
     implementation('io.github.dsibilio:badge-maker:1.0.4') {
         exclude group: 'org.slf4j'
     } // 2.x requires Java 17
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
 
     provided "org.jetbrains.teamcity:oauth:$teamCityApiVersion"
 
     agent project(path: ':agent', configuration: 'plugin')
 
     testImplementation 'org.spockframework:spock-core:2.3-groovy-3.0'
+    testImplementation 'io.ratpack:ratpack-groovy-test:1.9.0'
 }
 
 java {

--- a/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityConnectionConstants.java
+++ b/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityConnectionConstants.java
@@ -17,6 +17,7 @@ public final class DevelocityConnectionConstants {
     public static final String CUSTOM_CCUD_EXTENSION_COORDINATES = "customCommonCustomUserDataExtensionCoordinates";
     public static final String INSTRUMENT_COMMAND_LINE_BUILD_STEP = "instrumentCommandLineBuildStep";
     public static final String DEVELOCITY_ACCESS_KEY = "develocityAccessKey";
+    public static final String DEVELOCITY_ACCESS_TOKEN_EXPIRY = "develocityAccessTokenExpiry";
     public static final String ENFORCE_DEVELOCITY_URL = "enforceDevelocityUrl";
 
     // Constants defined by the BuildScanServiceMessageInjector
@@ -82,6 +83,10 @@ public final class DevelocityConnectionConstants {
 
     public String getDevelocityAccessKey() {
         return DEVELOCITY_ACCESS_KEY;
+    }
+
+    public String getDevelocityAccessTokenExpiry() {
+        return DEVELOCITY_ACCESS_TOKEN_EXPIRY;
     }
 
     public String getEnforceDevelocityUrl() {

--- a/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityConnectionProvider.java
+++ b/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityConnectionProvider.java
@@ -71,6 +71,11 @@ public final class DevelocityConnectionProvider extends OAuthProvider {
             description += String.format("* Develocity Access Key: %s\n", "******");
         }
 
+        String accessTokenExpiry = params.get(DEVELOCITY_ACCESS_TOKEN_EXPIRY);
+        if (accessTokenExpiry != null) {
+            description += String.format("* Develocity Access Token Expiry: %s\n", accessTokenExpiry);
+        }
+
         String enforceGeUrl = params.get(ENFORCE_DEVELOCITY_URL);
         if (enforceGeUrl != null) {
             description += String.format("* Enforce Develocity Server URL: %s\n", enforceGeUrl);
@@ -164,8 +169,24 @@ public final class DevelocityConnectionProvider extends OAuthProvider {
             if (accessKey != null && !DevelocityAccessKeyValidator.isValid(accessKey)) {
                 errors.add(new InvalidProperty(DEVELOCITY_ACCESS_KEY, "Invalid access key"));
             }
+            String accessTokenExpiry = properties.get(DEVELOCITY_ACCESS_TOKEN_EXPIRY);
+            if (accessTokenExpiry != null && !isValid(accessTokenExpiry)) {
+                errors.add(new InvalidProperty(DEVELOCITY_ACCESS_TOKEN_EXPIRY, "It should be an integer between 1 and 24"));
+            }
             return errors;
         };
+    }
+
+    private static boolean isValid(String accessTokenExpiry) {
+        try {
+            if (accessTokenExpiry != null && !accessTokenExpiry.isEmpty()) {
+                int expiry = Integer.parseInt(accessTokenExpiry);
+                return expiry > 0 && expiry <= 24;
+            }
+        } catch (NumberFormatException e) {
+            return false;
+        }
+        return true;
     }
 
 }

--- a/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityParametersProvider.java
+++ b/src/main/java/com/gradle/develocity/teamcity/connection/DevelocityParametersProvider.java
@@ -1,10 +1,14 @@
 package com.gradle.develocity.teamcity.connection;
 
+import com.gradle.develocity.teamcity.token.DevelocityAccessCredentials;
+import com.gradle.develocity.teamcity.token.ShortLivedTokenClient;
+import com.gradle.develocity.teamcity.token.ShortLivedTokenClientFactory;
 import jetbrains.buildServer.serverSide.SBuild;
 import jetbrains.buildServer.serverSide.SBuildType;
 import jetbrains.buildServer.serverSide.SProjectFeatureDescriptor;
 import jetbrains.buildServer.serverSide.oauth.OAuthConstants;
 import jetbrains.buildServer.serverSide.parameters.BuildParametersProvider;
+import org.apache.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -13,6 +17,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.gradle.develocity.teamcity.connection.DevelocityConnectionConstants.*;
 
@@ -24,31 +30,85 @@ import static com.gradle.develocity.teamcity.connection.DevelocityConnectionCons
 @SuppressWarnings({"DuplicatedCode", "Convert2Diamond"})
 public final class DevelocityParametersProvider implements BuildParametersProvider {
 
+    private static final Logger LOGGER = Logger.getLogger("jetbrains.buildServer.BUILDSCAN");
+
+    private final ShortLivedTokenClientFactory shortLivedTokenClientFactory;
+    private SBuild previousBuild;
+    private Map<String, String> cachedParametersFromPreviousBuild;
+
+    public DevelocityParametersProvider(ShortLivedTokenClientFactory shortLivedTokenClientFactory) {
+        this.shortLivedTokenClientFactory = shortLivedTokenClientFactory;
+    }
+
     @NotNull
     @Override
     public Map<String, String> getParameters(@NotNull SBuild build, boolean emulationMode) {
-        List<Map<String, String>> connections = getAllDevelocityConnections(build);
+        // Execute only once per build
+        if (build != previousBuild) {
+            List<Map<String, String>> connections = getAllDevelocityConnections(build);
 
-        // descriptorParameters can contain null values, but TeamCity handles these null parameters as if they were not set
-        Map<String, String> params = new HashMap<>();
-        for (int i = connections.size() - 1; i >= 0; i--) {
-            Map<String, String> connectionParams = connections.get(i);
-            setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
-            setParameter(DEVELOCITY_URL_CONFIG_PARAM, connectionParams.get(DEVELOCITY_URL), params);
-            setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, connectionParams.get(ALLOW_UNTRUSTED_SERVER), params);
-            setParameter(DEVELOCITY_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(DEVELOCITY_PLUGIN_VERSION), params);
-            setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
-            setParameter(DEVELOCITY_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(DEVELOCITY_EXTENSION_VERSION), params);
-            setParameter(CCUD_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_EXTENSION_VERSION), params);
-            setParameter(CUSTOM_DEVELOCITY_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_DEVELOCITY_EXTENSION_COORDINATES), params);
-            setParameter(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_CCUD_EXTENSION_COORDINATES), params);
-            setParameter(INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM, connectionParams.get(INSTRUMENT_COMMAND_LINE_BUILD_STEP), params);
-            setParameter(DEVELOCITY_ACCESS_KEY_ENV_VAR, connectionParams.get(DEVELOCITY_ACCESS_KEY), params);
-            setParameter(ENFORCE_DEVELOCITY_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_DEVELOCITY_URL), params);
-            // Set the legacy access key variable to support legacy GE plugins
-            setParameter(GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR, connectionParams.get(DEVELOCITY_ACCESS_KEY), params);
+            // descriptorParameters can contain null values, but TeamCity handles these null parameters as if they were not set
+            Map<String, String> params = new HashMap<>();
+            for (int i = connections.size() - 1; i >= 0; i--) {
+                Map<String, String> connectionParams = connections.get(i);
+                String allowUntrustedServer = connectionParams.get(ALLOW_UNTRUSTED_SERVER);
+                String token = createShortLivedToken(
+                    connectionParams.get(DEVELOCITY_ACCESS_KEY),
+                    connectionParams.get(DEVELOCITY_ACCESS_TOKEN_EXPIRY),
+                    allowUntrustedServer
+                );
+                if (token != null) {
+                    setParameter(DEVELOCITY_ACCESS_KEY_ENV_VAR, token, params);
+                    // Set the legacy access key variable to support legacy GE plugins
+                    setParameter(GRADLE_ENTERPRISE_ACCESS_KEY_ENV_VAR, token, params);
+                }
+                setParameter(GRADLE_PLUGIN_REPOSITORY_URL_CONFIG_PARAM, connectionParams.get(GRADLE_PLUGIN_REPOSITORY_URL), params);
+                setParameter(DEVELOCITY_URL_CONFIG_PARAM, connectionParams.get(DEVELOCITY_URL), params);
+                setParameter(ALLOW_UNTRUSTED_SERVER_CONFIG_PARAM, allowUntrustedServer, params);
+                setParameter(DEVELOCITY_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(DEVELOCITY_PLUGIN_VERSION), params);
+                setParameter(CCUD_PLUGIN_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_PLUGIN_VERSION), params);
+                setParameter(DEVELOCITY_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(DEVELOCITY_EXTENSION_VERSION), params);
+                setParameter(CCUD_EXTENSION_VERSION_CONFIG_PARAM, connectionParams.get(CCUD_EXTENSION_VERSION), params);
+                setParameter(CUSTOM_DEVELOCITY_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_DEVELOCITY_EXTENSION_COORDINATES), params);
+                setParameter(CUSTOM_CCUD_EXTENSION_COORDINATES_CONFIG_PARAM, connectionParams.get(CUSTOM_CCUD_EXTENSION_COORDINATES), params);
+                setParameter(INSTRUMENT_COMMAND_LINE_BUILD_STEP_CONFIG_PARAM, connectionParams.get(INSTRUMENT_COMMAND_LINE_BUILD_STEP), params);
+                setParameter(ENFORCE_DEVELOCITY_URL_CONFIG_PARAM, connectionParams.get(ENFORCE_DEVELOCITY_URL), params);
+            }
+            previousBuild = build;
+            cachedParametersFromPreviousBuild = params;
+            return params;
         }
-        return params;
+        return cachedParametersFromPreviousBuild;
+    }
+
+    private String createShortLivedToken(String accessKey, String expiry, String allowUntrustedServer) {
+        if (accessKey == null) {
+            return null;
+        }
+        if (!DevelocityAccessCredentials.isValid(accessKey)) {
+            LOGGER.error("Develocity access key format is not valid");
+            return null;
+        }
+        DevelocityAccessCredentials allKeys = DevelocityAccessCredentials.parse(accessKey);
+        if (allKeys.isEmpty()) {
+            return null;
+        }
+
+        Integer expiryAsInt = expiry != null ? Integer.parseInt(expiry) : null;
+        boolean allowUntrusted = Boolean.parseBoolean(allowUntrustedServer);
+
+        ShortLivedTokenClient tokenClient = shortLivedTokenClientFactory.create(allowUntrusted);
+
+        List<DevelocityAccessCredentials.HostnameAccessKey> shortLivedTokens = allKeys.stream()
+            .map(k -> tokenClient.get(
+                "https://" + k.getHostname(), k, expiryAsInt))
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+
+        return shortLivedTokens.isEmpty()
+            ? null
+            : DevelocityAccessCredentials.of(shortLivedTokens).getRaw();
     }
 
     private static void setParameter(String key, String value, Map<String, String> params) {

--- a/src/main/java/com/gradle/develocity/teamcity/token/DevelocityAccessCredentials.java
+++ b/src/main/java/com/gradle/develocity/teamcity/token/DevelocityAccessCredentials.java
@@ -1,0 +1,135 @@
+package com.gradle.develocity.teamcity.token;
+
+import com.google.common.base.Strings;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class DevelocityAccessCredentials {
+
+    private static final String KEY_DELIMITER = ";";
+    private static final String HOST_DELIMITER = "=";
+    private final List<HostnameAccessKey> keys;
+
+    private DevelocityAccessCredentials(List<HostnameAccessKey> keys) {
+        this.keys = keys;
+    }
+
+    public static DevelocityAccessCredentials of(List<HostnameAccessKey> keys) {
+        return new DevelocityAccessCredentials(keys);
+    }
+
+    public boolean isEmpty() {
+        return keys.isEmpty();
+    }
+
+    public boolean isSingleKey() {
+        return keys.size() == 1;
+    }
+
+    public Optional<HostnameAccessKey> find(String host) {
+        return keys.stream().filter(k -> k.hostname.equals(host)).findFirst();
+    }
+
+    public String getRaw() {
+        return keys.stream().map(HostnameAccessKey::getRaw).collect(Collectors.joining(KEY_DELIMITER));
+    }
+
+    public Stream<HostnameAccessKey> stream() {
+        return keys.stream();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DevelocityAccessCredentials that = (DevelocityAccessCredentials) o;
+        return Objects.equals(keys, that.keys);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(keys);
+    }
+
+    public static DevelocityAccessCredentials parse(String rawAccessKey) {
+        return new DevelocityAccessCredentials(Arrays.stream(rawAccessKey.split(KEY_DELIMITER))
+            .map(k -> k.split("="))
+            .filter(hostKey -> hostKey.length == 2)
+            .map(hostKey -> new HostnameAccessKey(hostKey[0], hostKey[1]))
+            .collect(Collectors.toList()));
+    }
+
+    public static boolean isValid(String value) {
+        if (Strings.isNullOrEmpty(value)) {
+            return false;
+        }
+
+        String[] entries = value.split(";");
+
+        for (String entry : entries) {
+            String[] parts = entry.split("=", 2);
+            if (parts.length < 2) {
+                return false;
+            }
+
+            String servers = parts[0];
+            String accessKey = parts[1];
+
+            if (Strings.isNullOrEmpty(servers) || Strings.isNullOrEmpty(accessKey)) {
+                return false;
+            }
+
+            for (String server : servers.split(",")) {
+                if (Strings.isNullOrEmpty(server)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public static class HostnameAccessKey {
+        private final String hostname;
+        private final String key;
+        private HostnameAccessKey(String hostname, String key) {
+            this.hostname = hostname;
+            this.key = key;
+        }
+
+        public static HostnameAccessKey of(String hostname, String key) {
+            return new HostnameAccessKey(hostname, key);
+        }
+
+        public String getHostname() {
+            return hostname;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public String getRaw() {
+            return hostname + HOST_DELIMITER + key;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            HostnameAccessKey that = (HostnameAccessKey) o;
+            return Objects.equals(hostname, that.hostname) && Objects.equals(key, that.key);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(hostname, key);
+        }
+    }
+
+}

--- a/src/main/java/com/gradle/develocity/teamcity/token/ShortLivedTokenClient.java
+++ b/src/main/java/com/gradle/develocity/teamcity/token/ShortLivedTokenClient.java
@@ -1,0 +1,114 @@
+package com.gradle.develocity.teamcity.token;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+public class ShortLivedTokenClient {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ShortLivedTokenClient.class);
+    private static final RequestBody EMPTY_BODY = RequestBody.create(new byte[]{});
+    private static final int MAX_RETRIES = 3;
+    private static final Duration RETRY_INTERVAL = Duration.ofSeconds(1);
+
+    private final OkHttpClient httpClient;
+
+    public ShortLivedTokenClient(boolean allowUntrusted) {
+        OkHttpClient.Builder builder = new OkHttpClient().newBuilder().callTimeout(10, TimeUnit.SECONDS);
+        if (allowUntrusted) {
+            builder.hostnameVerifier((hostname, session) -> true);
+            try {
+                TrustManager[] allTrustingTrustManager = createAllTrustingTrustManager();
+                SSLContext sslContext = SSLContext.getInstance("TLS");
+                sslContext.init(null, allTrustingTrustManager, null);
+
+                builder.sslSocketFactory(sslContext.getSocketFactory(), (X509TrustManager) allTrustingTrustManager[0]);
+            } catch (NoSuchAlgorithmException | KeyManagementException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        this.httpClient = builder.build();
+    }
+
+    public Optional<DevelocityAccessCredentials.HostnameAccessKey> get(String server, DevelocityAccessCredentials.HostnameAccessKey accessKey, @Nullable Integer expiry) {
+        String url = normalize(server) + "api/auth/token";
+        if (expiry != null) {
+            url = url + "?expiresInHours=" + expiry;
+        }
+
+        Request request = new Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer " + accessKey.getKey())
+            .addHeader("Content-Type", "application/json")
+            .post(EMPTY_BODY)
+            .build();
+
+        int tryCount = 0;
+        Integer errorCode = null;
+        while (tryCount < MAX_RETRIES) {
+            try (Response response = httpClient.newCall(request).execute()) {
+                if (response.code() == 200 && response.body() != null) {
+                    return Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of(accessKey.getHostname(), response.body().string()));
+                } else if (response.code() == 401) {
+                    LOGGER.warn("Develocity short lived token request failed {} with status code 401", url);
+                    return Optional.empty();
+                } else {
+                    tryCount++;
+                    errorCode = response.code();
+                    Thread.sleep(RETRY_INTERVAL.toMillis());
+                }
+            } catch (IOException e) {
+                LOGGER.warn("Short lived token request failed {}", url, e);
+                return Optional.empty();
+            } catch (InterruptedException e) {
+                // Ignore sleep exception
+            }
+        }
+        LOGGER.warn("Develocity short lived token request failed {} with status code {}", url, errorCode);
+        return Optional.empty();
+    }
+
+    private static String normalize(String server) {
+        if (server.endsWith("/")) {
+            return server;
+        }
+
+        return server + "/";
+    }
+
+    private static TrustManager[] createAllTrustingTrustManager() {
+        return new TrustManager[]{
+            new X509TrustManager() {
+                @Override
+                public X509Certificate[] getAcceptedIssuers() {
+                    return new X509Certificate[]{};
+                }
+
+                @Override
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                @Override
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+            }
+        };
+    }
+
+}

--- a/src/main/java/com/gradle/develocity/teamcity/token/ShortLivedTokenClientFactory.java
+++ b/src/main/java/com/gradle/develocity/teamcity/token/ShortLivedTokenClientFactory.java
@@ -1,0 +1,9 @@
+package com.gradle.develocity.teamcity.token;
+
+public class ShortLivedTokenClientFactory {
+
+    public ShortLivedTokenClient create(boolean allowUntrusted) {
+        return new ShortLivedTokenClient(allowUntrusted);
+    }
+
+}

--- a/src/main/resources/META-INF/build-server-plugin-buildscans.xml
+++ b/src/main/resources/META-INF/build-server-plugin-buildscans.xml
@@ -67,4 +67,6 @@
           class="com.gradle.develocity.teamcity.connection.DevelocityPasswordProvider">
     </bean>
 
+    <bean id="shortLivedTokenClientFactory" class="com.gradle.develocity.teamcity.token.ShortLivedTokenClientFactory" />
+
 </beans>

--- a/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
+++ b/src/main/resources/buildServerResources/develocityConnectionDialog.jsp
@@ -43,6 +43,15 @@
 </tr>
 
 <tr>
+    <td><label for="${keys.develocityAccessTokenExpiry}">Develocity short-lived access token expiry:</label></td>
+    <td>
+        <props:textProperty name="${keys.develocityAccessTokenExpiry}" className="longField"/>
+        <span class="error" id="error_${keys.develocityAccessTokenExpiry}"></span>
+        <span class="smallNote">The short-lived access tokens expiry in hours. Defaults to 2 hours. For more information, please refer to the <a href="https://docs.gradle.com/enterprise/api-manual/#short_lived_access_tokens" target="_blank">documentation</a>.</span>
+    </td>
+</tr>
+
+<tr>
     <td><label for="${keys.enforceDevelocityUrl}">Enforce Develocity Server URL:</label></td>
     <td>
         <props:checkboxProperty name="${keys.enforceDevelocityUrl}"/>

--- a/src/test/groovy/com/gradle/develocity/teamcity/token/DevelocityAccessCredentialsTest.groovy
+++ b/src/test/groovy/com/gradle/develocity/teamcity/token/DevelocityAccessCredentialsTest.groovy
@@ -1,0 +1,130 @@
+package com.gradle.develocity.teamcity.token
+
+
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+@Unroll
+@Subject(DevelocityAccessCredentials)
+class DevelocityAccessCredentialsTest extends Specification {
+
+    def 'valid access key: #accessKey'(String accessKey) {
+        expect:
+        DevelocityAccessCredentials.isValid(accessKey)
+
+        where:
+        accessKey << [
+            'server=secret',
+            'server=secret ',
+            'server = secret',
+            ' server= secret',
+
+            'sever1,server2,server3=secret',
+            ' sever1, server2 , server3 = secret ',
+
+            'server1=secret1;server2=secret2;server3=secret3',
+            ' server1= secret1; server2 , sever3 = secret2 ;'
+        ]
+    }
+
+    def 'invalid access key: #accessKey'(String accessKey) {
+        expect:
+        !DevelocityAccessCredentials.isValid(accessKey)
+
+        where:
+        accessKey << [
+            null,
+            '',
+            ' ',
+            'server=',
+            '=secret',
+            'secret',
+            'server=secret; ',
+            ';server=secret',
+            'server1, server2,, server3 = secret '
+        ]
+    }
+
+    def 'parse access key'() {
+        when:
+        def creds = DevelocityAccessCredentials.parse(accessKey)
+
+        then:
+        creds == expected
+
+        where:
+        accessKey                          | expected
+        'host1=key1'                       | DevelocityAccessCredentials.of([DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1')])
+        'host2=key2;host1=key1;host3=key3' | DevelocityAccessCredentials.of([
+                DevelocityAccessCredentials.HostnameAccessKey.of('host2', 'key2'),
+                DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1'),
+                DevelocityAccessCredentials.HostnameAccessKey.of('host3', 'key3')])
+        ''                                 | DevelocityAccessCredentials.of([])
+        'foo'                              | DevelocityAccessCredentials.of([])
+    }
+
+    def 'is empty'() {
+        given:
+        def creds = DevelocityAccessCredentials.of(keys)
+
+        expect:
+        creds.isEmpty() == expected
+
+        where:
+        keys                                                                | expected
+        []                                                                  | true
+        [DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1')] | false
+    }
+
+    def 'is single'() {
+        given:
+        def creds = DevelocityAccessCredentials.of(keys)
+
+        expect:
+        creds.isSingleKey() == expected
+
+        where:
+        keys                                                                   | expected
+        []                                                                     | false
+        [DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1')]    | true
+        [
+                DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1'),
+                DevelocityAccessCredentials.HostnameAccessKey.of('host2', 'key2'),
+        ]                                                                      | false
+    }
+
+    def 'raw'() {
+        given:
+        def creds = DevelocityAccessCredentials.of([
+                DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1'),
+                DevelocityAccessCredentials.HostnameAccessKey.of('host2', 'key2'),
+        ])
+
+        when:
+        def raw = creds.getRaw()
+
+        then:
+        raw == 'host1=key1;host2=key2'
+    }
+
+    def 'find'() {
+        given:
+        def creds = DevelocityAccessCredentials.of([
+                DevelocityAccessCredentials.HostnameAccessKey.of('host1', 'key1'),
+                DevelocityAccessCredentials.HostnameAccessKey.of('host2', 'key2'),
+        ])
+
+        def found = creds.find(host)
+
+        expect:
+        found == expected
+
+        where:
+        host    | expected
+        'host2' | Optional.of(DevelocityAccessCredentials.HostnameAccessKey.of('host2', 'key2'))
+        'host3' | Optional.empty()
+    }
+
+
+}

--- a/src/test/groovy/com/gradle/develocity/teamcity/token/ShortLivedTokenClientTest.groovy
+++ b/src/test/groovy/com/gradle/develocity/teamcity/token/ShortLivedTokenClientTest.groovy
@@ -1,0 +1,171 @@
+package com.gradle.develocity.teamcity.token
+
+
+import io.netty.handler.ssl.SslContext
+import io.netty.handler.ssl.SslContextBuilder
+import io.netty.handler.ssl.SslProvider
+import io.netty.handler.ssl.util.SelfSignedCertificate
+import ratpack.groovy.test.embed.GroovyEmbeddedApp
+import ratpack.server.ServerConfig
+import spock.lang.Specification
+
+class ShortLivedTokenClientTest extends Specification {
+
+    def "get token"() {
+        given:
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            handlers {
+                post("api/auth/token") {
+                    response.status(200)
+                    response.send('some-token')
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get(mockDevelocity.address.toString(), key, null)
+
+        then:
+        token.get().key == 'some-token'
+        token.get().hostname == mockDevelocity.address.host
+    }
+
+    def "get token with expiry"() {
+        given:
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            handlers {
+                post("api/auth/token") {
+                    if (request.queryParams.get('expiresInHours') == '3') {
+                        response.status(200)
+                        response.send('some-token')
+                    }
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get(mockDevelocity.address.toString(), key, 3)
+
+        then:
+        token.get().key == 'some-token'
+        token.get().hostname == mockDevelocity.address.host
+    }
+
+    def "get token fails with 401"() {
+        given:
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            handlers {
+                post("api/auth/token") {
+                    response.status(401)
+                    response.send('{"status":401,"type":"urn:gradle:develocity:api:problems:client-error","title":"Something was wrong with the request."}')
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get(mockDevelocity.address.toString(), key, null)
+
+        then:
+        !token.isPresent()
+    }
+
+    def "get token fails after retries"() {
+        given:
+        def requestCounter = 0
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            handlers {
+                post("api/auth/token") {
+                    requestCounter++
+                    response.status(500)
+                    response.send('Internal error')
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get(mockDevelocity.address.toString(), key, null)
+
+        then:
+        requestCounter == 3
+        !token.isPresent()
+    }
+
+    def "get token sever fails with exception"() {
+        given:
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get('http://localhost:8888', key, null)
+
+        then:
+        !token.isPresent()
+    }
+
+    def "get token successfully after retry"() {
+        given:
+        def firstRequest = true
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            handlers {
+                post("api/auth/token") {
+                    if (firstRequest) {
+                        response.status(503)
+                        response.send('Not available')
+                        firstRequest = false
+                    } else {
+                        response.status(200)
+                        response.send('some-token')
+                    }
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(false).get(mockDevelocity.address.toString(), key, null)
+
+        then:
+        token.get().key == 'some-token'
+        token.get().hostname == mockDevelocity.address.host
+    }
+
+    def "get token for an untrusted server - #allowUntrustedServer"(boolean allowUntrustedServer) {
+        given:
+        def mockDevelocity = GroovyEmbeddedApp.of {
+            serverConfig(ServerConfig.builder().tap {
+                def cert = new SelfSignedCertificate('localhost')
+                def sslContext = SslContextBuilder.forServer(cert.certificate(), cert.privateKey())
+                        .sslProvider(SslProvider.JDK)
+                        .build() as SslContext
+                ssl(sslContext)
+            })
+            handlers {
+                post("api/auth/token") {
+                    response.status(200)
+                    response.send('some-token')
+                }
+            }
+        }
+        def key = DevelocityAccessCredentials.HostnameAccessKey.of('localhost', 'xyz')
+
+        when:
+        def token = new ShortLivedTokenClient(allowUntrustedServer).get(mockDevelocity.address.toString(), key, null)
+
+        then:
+        if (allowUntrustedServer) {
+            assert token.get().key == 'some-token'
+            assert token.get().hostname == mockDevelocity.address.host
+        } else {
+            assert !token.isPresent()
+        }
+
+        mockDevelocity.server.stop()
+
+        where:
+        allowUntrustedServer << [true, false]
+    }
+
+}


### PR DESCRIPTION
Create a short-lived token prior to running builds, given a valid access key is provided. A new config parameter is added to customize the expiry:

<img width="551" alt="image" src="https://github.com/user-attachments/assets/24967725-e6fd-4d39-8044-8802e592b612" />

Some notes on the implementation using `DevelocityParametersProvider`:
- It is executed on the main instance; hence, the HTTP query to get the token is initiated from there, not from the agents. This is not necessarily the case for all CI integrations we have.
- It is executed several times for the same build, to avoid unnecessary token creation, we cache the result to execute it once per build