### PR TITLE
Rename the plugin to Develocity integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ teamcity {
     server {
         descriptor {
             name = 'Develocity'
-            displayName = 'Develocity for TeamCity'
+            displayName = 'Develocity integration'
             description = 'Provides integration with Develocity via auto-instrumentation of the CI jobs.'
             version = project.version
             vendorName = 'Gradle Inc.'


### PR DESCRIPTION
The name cannot contain "teamcity" or "plugin" as mentioned in the error we got during publication:

> Cannot upload plugin. Plugin name should not contain the following words: teamcity, plugin